### PR TITLE
fixed the bug in the massage for only filtering the category

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -187,6 +187,7 @@ const Home: FC<Props> = ({
     results = copyItems.filter((item: Item) => {
       return conditions.includes(item.condition);
     });
+
     return results;
   };
 
@@ -206,7 +207,11 @@ const Home: FC<Props> = ({
         graphqlOperation(listAdverts, { filter: filterValue })
       )) as GraphQLResult<ListAdvertsQuery>;
 
-      filteredResult = filterConditions(result, conditionValues);
+      if (conditionValues.length === 0) {
+        filteredResult = [...result?.data?.listAdverts?.items];
+      } else {
+        filteredResult = filterConditions(result, conditionValues);
+      }
     } else {
       result = (await API.graphql(
         graphqlOperation(listAdverts, { filter: { version: { eq: 0 } } })
@@ -216,6 +221,8 @@ const Home: FC<Props> = ({
     if (filteredResult.length > 0) {
       advertItems = [...filteredResult];
       setError(false);
+    } else if (filterValue.or.length > 0 && filteredResult.length === 0) {
+      setError(true);
     } else if (conditionValues.length > 0 && filteredResult.length === 0) {
       setError(true);
     } else {


### PR DESCRIPTION
### **Explain the changes you've made**

to show message when only filter category and no items meets criteria

### **Explain why these changes are made**

Because the message didnt show up

### **Explain your solution**

fixed error state and conditions in if statement for render items

### **How to test the changes?**

test if only filter category and when the criteria is not matched to see if the message shows up 