### PR TITLE
fixed cancelbtn to fetch all items without clicking save button

### DIFF
--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -99,7 +99,6 @@ interface Props {
   setFilterValueUpdated: React.Dispatch<React.SetStateAction<boolean>>;
   filterValue: any;
   setFilterValue: React.Dispatch<React.SetStateAction<any>>;
-  conditionValues: any;
   setConditionValues: React.Dispatch<React.SetStateAction<any>>;
   filterValueUpdated: boolean;
 }
@@ -168,6 +167,7 @@ const FilterMenu: FC<Props> = ({
     });
     setConditionValues([]);
     setSaveValues({});
+    setFilterValueUpdated(!filterValueUpdated);
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,7 @@ import { Redirect } from "react-router-dom";
 import { graphqlOperation, GraphQLResult } from "@aws-amplify/api";
 import { API, Storage } from "aws-amplify";
 import styled from "styled-components";
-import { MdNewReleases, MdSearch, MdTune } from "react-icons/md";
-import { MdPhotoCamera } from "react-icons/md";
+import { MdNewReleases, MdSearch, MdTune, MdPhotoCamera } from "react-icons/md";
 import { listAdverts } from "../graphql/queries";
 import { ListAdvertsQuery } from "../API";
 import AdvertContainer from "../components/AdvertContainer";
@@ -246,7 +245,6 @@ const Home: FC<Props> = ({
       )) as GraphQLResult<ListAdvertsQuery>;
     }
 
-    setItems(advertItems);
     if (filteredResult.length > 0) {
       advertItems = [...filteredResult];
       setError(false);
@@ -254,16 +252,18 @@ const Home: FC<Props> = ({
       setError(true);
     } else if (conditionValues.length > 0 && filteredResult.length === 0) {
       setError(true);
-    } else {
+    } else if (filterValue.or.length === 0) {
       advertItems = result?.data?.listAdverts?.items;
       setError(false);
     }
 
     setItems(advertItems);
+
     setFilterValue({
       ...filterValue,
       or: [],
     });
+
     setConditionValues([]);
     setPaginationOption({
       ...paginationOption,
@@ -273,13 +273,10 @@ const Home: FC<Props> = ({
 
     setRenderItems(advertItems.slice(0, paginationOption.amountToShow));
   };
-  useEffect(() => {
-    fetchItems();
-  }, [filterValueUpdated]);
 
   useEffect(() => {
     fetchItems();
-  }, []);
+  }, [filterValueUpdated]);
 
   if (qrCamera.result.length > 2) {
     return <Redirect to={`/item/${qrCamera.result}`} />;
@@ -334,7 +331,6 @@ const Home: FC<Props> = ({
               setFilterValueUpdated={setFilterValueUpdated}
               filterValue={filterValue}
               setFilterValue={setFilterValue}
-              conditionValues={conditionValues}
               setConditionValues={setConditionValues}
             />
           </SearchFilterDiv>


### PR DESCRIPTION
### **Explain the changes you've made**

Fixed the cancel button on filter view to direct fetch all items without clicking save button.
Cleaned some codes, had 2 useEffect for fetching items and  2 md icon import modules .

### **Explain why these changes are made**

After discussing with UX designer Gustaf,  it is better User experience. 

### **Explain your solution**

update FilterValueUpdated value in cancel function

### **How to test the changes?**

go to home page, click on the filter values and cancel button without clicking the save button and close the filter view to see if all items fetched. 