### PR TITLE
Fix/filter save btn disabled

### DIFF
--- a/src/components/FilterCheckbox.tsx
+++ b/src/components/FilterCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import styled from "styled-components";
 
 const InputGroup = styled.div`
@@ -45,28 +45,55 @@ interface Props {
   group: any;
   saveValues: any;
   setSaveValues: any;
+  isDisabled: boolean;
+  setIsDisabled: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const FilterCheckbox: FC<Props> = ({
   setSaveValues,
   saveValues,
   group,
+  isDisabled,
+  setIsDisabled,
 }: Props) => {
-  const handleInputChange = (
-    e: React.ChangeEvent<any>,
-    groupName: any,
-    element: any
-  ) => {
-    const { target } = e;
-
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    // eslint-disable-next-line no-console
-
+  const handleInputChange = (e: React.ChangeEvent<any>, groupName: any) => {
     setSaveValues({
       ...saveValues,
-      [groupName]: { ...saveValues[groupName], [element]: value },
+      [groupName]: {
+        ...saveValues[groupName],
+        [e.target.name]: e.target.checked,
+      },
     });
   };
+
+  useEffect(() => {
+    console.log("saveValues", saveValues);
+  }, [saveValues]);
+
+  let cates: any = [];
+  let condis: any = [];
+
+  Object.entries(saveValues).forEach((entry: any) => {
+    const [key, value] = entry;
+
+    Object.keys(value).forEach((innerKey: string) => {
+      if (value[innerKey] === true) {
+        if (key === "category") {
+          cates.push(innerKey);
+        } else if (key === "condition") {
+          condis.push(innerKey);
+        }
+      }
+    });
+  });
+
+  console.log("cate", cates, "condi", condis);
+
+  if (cates.length === 0 && condis.length === 0) {
+    setIsDisabled(true);
+  } else {
+    setIsDisabled(false);
+  }
 
   let checkboxes: any;
 
@@ -79,7 +106,7 @@ const FilterCheckbox: FC<Props> = ({
           <input
             type="checkbox"
             name={element}
-            onChange={(e) => handleInputChange(e, [group.name], element)}
+            onChange={(e) => handleInputChange(e, [group.name])}
             checked={
               !!(saveValues[group.name] && saveValues[group.name][element])
             }

--- a/src/components/FilterCheckbox.tsx
+++ b/src/components/FilterCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import styled from "styled-components";
 
 const InputGroup = styled.div`
@@ -45,7 +45,6 @@ interface Props {
   group: any;
   saveValues: any;
   setSaveValues: any;
-  isDisabled: boolean;
   setIsDisabled: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -53,7 +52,6 @@ const FilterCheckbox: FC<Props> = ({
   setSaveValues,
   saveValues,
   group,
-  isDisabled,
   setIsDisabled,
 }: Props) => {
   const handleInputChange = (e: React.ChangeEvent<any>, groupName: any) => {
@@ -65,10 +63,6 @@ const FilterCheckbox: FC<Props> = ({
       },
     });
   };
-
-  useEffect(() => {
-    console.log("saveValues", saveValues);
-  }, [saveValues]);
 
   let cates: any = [];
   let condis: any = [];
@@ -86,8 +80,6 @@ const FilterCheckbox: FC<Props> = ({
       }
     });
   });
-
-  console.log("cate", cates, "condi", condis);
 
   if (cates.length === 0 && condis.length === 0) {
     setIsDisabled(true);

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -205,6 +205,7 @@ const FilterMenu: FC<Props> = ({
           disabled={isDisabled}
           style={{
             backgroundColor: isDisabled ? "#F5F5F5" : "#50811B",
+            color: isDisabled ? "#A3A3A3" : "white",
           }}
           className="saveBtn"
           type="button"
@@ -212,7 +213,12 @@ const FilterMenu: FC<Props> = ({
         >
           Spara
         </button>
-        <button className="resetBtn" type="button" onClick={handleCancelFilter}>
+        <button
+          style={{ display: isDisabled ? "none" : "block" }}
+          className="resetBtn"
+          type="button"
+          onClick={handleCancelFilter}
+        >
           Avbryt/ Nollställ
         </button>
       </FilterBody>

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -171,7 +171,6 @@ const FilterMenu: FC<Props> = ({
     setFilterValueUpdated(!filterValueUpdated);
   };
 
-  console.log("disabled", isDisabled);
   return (
     <FilterCtn className={isOpen ? "show" : "hide"}>
       <FilterHeader>
@@ -186,14 +185,12 @@ const FilterMenu: FC<Props> = ({
       </FilterHeader>
       <FilterBody>
         <FilterCheckbox
-          isDisabled={isDisabled}
           setIsDisabled={setIsDisabled}
           setSaveValues={setSaveValues}
           group={fieldsForm[2]}
           saveValues={saveValues}
         />
         <FilterCheckbox
-          isDisabled={isDisabled}
           setIsDisabled={setIsDisabled}
           setSaveValues={setSaveValues}
           group={fieldsForm[9]}

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -115,6 +115,7 @@ const FilterMenu: FC<Props> = ({
   setConditionValues,
 }: Props) => {
   const [saveValues, setSaveValues] = useState({});
+  const [isDisabled, setIsDisabled] = useState(true);
 
   useEffect(() => {
     if (isOpen) {
@@ -170,6 +171,7 @@ const FilterMenu: FC<Props> = ({
     setFilterValueUpdated(!filterValueUpdated);
   };
 
+  console.log("disabled", isDisabled);
   return (
     <FilterCtn className={isOpen ? "show" : "hide"}>
       <FilterHeader>
@@ -184,18 +186,30 @@ const FilterMenu: FC<Props> = ({
       </FilterHeader>
       <FilterBody>
         <FilterCheckbox
+          isDisabled={isDisabled}
+          setIsDisabled={setIsDisabled}
           setSaveValues={setSaveValues}
           group={fieldsForm[2]}
           saveValues={saveValues}
         />
         <FilterCheckbox
+          isDisabled={isDisabled}
+          setIsDisabled={setIsDisabled}
           setSaveValues={setSaveValues}
           group={fieldsForm[9]}
           saveValues={saveValues}
         />
         {/* all the small filtering components, the following p tag is just for showing how it looks like, can be removed when component is added */}
 
-        <button className="saveBtn" type="button" onClick={handleSaveFilter}>
+        <button
+          disabled={isDisabled}
+          style={{
+            backgroundColor: isDisabled ? "#F5F5F5" : "#50811B",
+          }}
+          className="saveBtn"
+          type="button"
+          onClick={handleSaveFilter}
+        >
           Spara
         </button>
         <button className="resetBtn" type="button" onClick={handleCancelFilter}>


### PR DESCRIPTION
### **Explain the changes you've made**

Fixed Spara button to be disabled and cancel button to be hidden when none filter values is checked. 

### **Explain why these changes are made**

Because this are the changes based on updated wireframe in Figma and the next task to show filter options is related to the code in this task so this needs to be done first. 

### **Explain your solution**

handling the checkbox values in checkbox components. 

### **How to test the changes?**

go to home page, check on the filter values and uncheck all the filter values to see how the spara button and cancel button look like. 