### PR TITLE
Fix/create advert crash fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14552,6 +14552,14 @@
         }
       }
     },
+    "react-toastify": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-7.0.4.tgz",
+      "integrity": "sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.4",
     "react-simple-wysiwyg": "^1.0.2",
+    "react-toastify": "^7.0.4",
     "sanitize-html": "^2.3.3",
     "sort-by-typescript": "^1.1.0",
     "styled-components": "^5.2.0",

--- a/src/components/EditItemForm.tsx
+++ b/src/components/EditItemForm.tsx
@@ -121,12 +121,16 @@ const EditItemForm: FC<Props> = ({
   }
   return (
     <>
-      {!redirect ? (
-        (
+      {fileUploading && (
+        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+      )}
+
+      {!fileUploading && (
+        <>
           <button type="button" onClick={() => setEditItem(false)}>
             X
           </button>
-        ) && <ItemImg src={imageURL} /> && (
+          {/* <ItemImg src={imageURL} /> */}
           <Form
             values={values}
             fields={fields}
@@ -135,9 +139,7 @@ const EditItemForm: FC<Props> = ({
             handleSubmit={handleSubmit}
             handleCheckboxChange={handleCheckboxChange}
           />
-        )
-      ) : (
-        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+        </>
       )}
     </>
   );

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -244,7 +244,7 @@ export default function Form(props: {
       </form>
       <ToastContainer
         position="top-center"
-        autoClose={5000}
+        autoClose={6000}
         hideProgressBar
         newestOnTop={false}
         closeOnClick

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -6,7 +6,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import styled from "styled-components";
+import { ToastContainer } from "react-toastify";
 import { IFields } from "../interfaces/IForm";
+import "react-toastify/dist/ReactToastify.css";
 
 const FormContainerDiv = styled.div`
   width: 100%;
@@ -240,6 +242,17 @@ export default function Form(props: {
         {fields}
         <button type="submit">Submit</button>
       </form>
+      <ToastContainer
+        position="top-center"
+        autoClose={5000}
+        hideProgressBar
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
     </FormContainerDiv>
   );
 }

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -213,11 +213,11 @@ export default function Form(props: {
             id={field.name}
             onChange={props.handleInputChange}
             defaultValue={
-              props.values[field.name] ? props.values[field.name] : "select"
+              props.values[field.name] ? props.values[field.name] : ""
             }
             required={field.required}
           >
-            <option value="select" disabled>
+            <option value="" disabled>
               Välj ett alternativ
             </option>
             {data.map((x: string, idx: number) => {

--- a/src/components/RegiveForm.tsx
+++ b/src/components/RegiveForm.tsx
@@ -1,9 +1,10 @@
 import React, { FC } from "react";
+import { API, graphqlOperation } from "aws-amplify";
+import Loader from "react-loader-spinner";
 import Form from "./Form";
 import useForm from "../hooks/useForm";
 import { updateAdvert } from "../graphql/mutations";
 import { fieldsEditForm as fields } from "../utils/formUtils";
-import Loader from "react-loader-spinner";
 
 interface IareaOfUse {
   indoors: boolean;
@@ -101,11 +102,15 @@ const RegiveForm: FC<Props> = ({
   }
   return (
     <>
-      {!redirect && (
+      {fileUploading && (
+        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+      )}
+
+      {!fileUploading && (
+        <>
           <button type="button" onClick={() => setRegive(false)}>
             X
           </button>
-        ) && (
           <Form
             values={values}
             fields={fields}
@@ -114,9 +119,7 @@ const RegiveForm: FC<Props> = ({
             handleSubmit={handleSubmit}
             handleCheckboxChange={handleCheckboxChange}
           />
-        )}
-      {redirect && (
-        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+        </>
       )}
     </>
   );

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -87,7 +87,7 @@ const useForm = (initialValues: any, mutation: string) => {
       } catch (error) {
         console.error(error);
         setFileUploading(false);
-        toast("Ett fel inträffade när bilden laddades upp, försök igen!");
+        toast.warn("Ett fel inträffade när bilden laddades upp, försök igen!");
         return;
       }
     }
@@ -108,7 +108,7 @@ const useForm = (initialValues: any, mutation: string) => {
     } catch (error) {
       console.error(error);
       setFileUploading(false);
-      toast("Ett okänt fel inträffade 😵 Försök igen!");
+      toast.warn("Ett okänt fel inträffade 😵 Försök igen!");
       return;
     }
 

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -98,26 +98,26 @@ const AddItem: FC<Props> = ({
   return (
     <main>
       <Suspense fallback={<div>Loading...</div>}>
-      {!fileUploading && file && <ItemImg src={imageURL} />}
+        {!fileUploading && file && <ItemImg src={imageURL} />}
 
-      {!fileUploading && !alreadyAQRCode && (
-        <Form
-          values={values}
-          fields={fields}
-          mutation={createAdvert}
-          handleInputChange={handleInputChange}
-          handleSubmit={handleSubmit}
-          handleCheckboxChange={handleCheckboxChange}
-        />
-      )}
+        {!fileUploading && !alreadyAQRCode && (
+          <Form
+            values={values}
+            fields={fields}
+            mutation={createAdvert}
+            handleInputChange={handleInputChange}
+            handleSubmit={handleSubmit}
+            handleCheckboxChange={handleCheckboxChange}
+          />
+        )}
 
-      {!fileUploading && alreadyAQRCode && (
-        <OpenCamera qrCamera={qrCamera} setQrCamera={setQrCamera} />
-      )}
+        {!fileUploading && alreadyAQRCode && (
+          <OpenCamera qrCamera={qrCamera} setQrCamera={setQrCamera} />
+        )}
 
-      {fileUploading && (
-        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
-      )}
+        {fileUploading && (
+          <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+        )}
       </Suspense>
     </main>
   );

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -83,8 +83,6 @@ const AddItem: FC<Props> = ({
   );
   const [imageURL, setImageURL] = useState("");
 
-  useEffect(() => {}, [fileUploading]);
-
   useEffect(() => {
     if (file) {
       setImageURL(URL.createObjectURL(file));
@@ -100,23 +98,26 @@ const AddItem: FC<Props> = ({
   return (
     <main>
       <Suspense fallback={<div>Loading...</div>}>
-        {!redirect && file && <ItemImg src={imageURL} />}
-        {!redirect && !alreadyAQRCode ? (
-          <Form
-            values={values}
-            fields={fields}
-            mutation={createAdvert}
-            handleInputChange={handleInputChange}
-            handleSubmit={handleSubmit}
-            handleCheckboxChange={handleCheckboxChange}
-          />
-        ) : (
-          <OpenCamera qrCamera={qrCamera} setQrCamera={setQrCamera} />
-        )}
+      {!fileUploading && file && <ItemImg src={imageURL} />}
 
-        {fileUploading && redirect && (
-          <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
-        )}
+      {!fileUploading && !alreadyAQRCode && (
+        <Form
+          values={values}
+          fields={fields}
+          mutation={createAdvert}
+          handleInputChange={handleInputChange}
+          handleSubmit={handleSubmit}
+          handleCheckboxChange={handleCheckboxChange}
+        />
+      )}
+
+      {!fileUploading && alreadyAQRCode && (
+        <OpenCamera qrCamera={qrCamera} setQrCamera={setQrCamera} />
+      )}
+
+      {fileUploading && (
+        <Loader type="ThreeDots" color="#9db0c6" height={200} width={200} />
+      )}
       </Suspense>
     </main>
   );


### PR DESCRIPTION
- Fixes a bug that makes the app crash if you create an advert but skip certain required fields: https://app.clickup.com/t/jd78rz
- Also fixes bug that activated camera during image uploading: https://app.clickup.com/t/h93puq
- Added a Toast to show error to the user if something goes wrong

**Explain the solution**
This is fixed with lots of small changes.

First of all I catch errors that can occur when we are creating/editing/uploading stuff to the database. So if we got an error, i abort the submission and show an error to the user instead of a crash.

Also changed the image upload flow a bit so that we wait for the image to be uploaded, before we just uploaded it asynchronously and assumed it always works. Now we wait until the image is actually uploaded and show an error to the user if it was not.

Before it was possible to submit an advert even if some required select inputs was empty, and that resulted in app crashes. 
That happened because we had a default value for the select inputs, and that value is forbidden in our graphql queries. So I simply removed the default value so the html validation works again and the user can not submit faulty select values. 

Also changed the logic for when the Loader is shown, before we was listening for redirects, but i think its more logical to listen on fileUploading state instead.

**How to test the changes**
npm install
Then try to create/update/regive adverts and everything should work like before. Hopefully without any crashes 🤞

Example when displaying an error:
![Screenshot 2021-05-07 at 15 58 06](https://user-images.githubusercontent.com/21363149/117460811-31561600-af4d-11eb-8cd4-2d5b473a36cf.png)







