### PR TITLE
Fix/regive giver

### DIFF
--- a/src/components/AdvertContainer.tsx
+++ b/src/components/AdvertContainer.tsx
@@ -88,7 +88,6 @@ const AdvertContainer: FC<IAdvert> = ({
     filteredItems = items;
   }
 
-
   return (
     <AdvertContainerDiv>
       <Suspense fallback={<div>Loading...</div>}>

--- a/src/components/AdvertContainer.tsx
+++ b/src/components/AdvertContainer.tsx
@@ -125,11 +125,18 @@ const AdvertContainer: FC<IAdvert> = ({
               </span>
             </OptionWrapper>
           )}
-
           {itemsFrom === "haffat" && items.length !== 0 && (
             <h3>Saker att hämta</h3>
           )}
-          {itemsFrom === "pickedUp" && <h3>Saker som har hämtats</h3>}
+          {itemsFrom === "haffat" && items.length === 0 && (
+            <h3>Inga saker att hämta</h3>
+          )}
+          {itemsFrom === "pickedUp" && items.length !== 0 && (
+            <h3>Saker som har hämtats</h3>
+          )}
+          {itemsFrom === "pickedUp" && items.length === 0 && (
+            <h3>Inga saker har hämtats</h3>
+          )}
           {itemsFrom === "myAdds" && <h3>Mina annonser</h3>}
         </div>
         {filteredItems.map((filteredItem: any) => (

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -176,6 +176,8 @@ const Card: FC<Props> = ({
     return () => {};
   }, [itemUpdated]);
 
+
+
   return (
     <CardDiv
       as={Link}

--- a/src/components/EditItemForm.tsx
+++ b/src/components/EditItemForm.tsx
@@ -41,7 +41,6 @@ interface Props {
     description?: string;
     department?: string;
     location?: string;
-    instructions?: string;
     contactPerson?: string;
     email?: string;
     phoneNumber?: string;
@@ -99,7 +98,6 @@ const EditItemForm: FC<Props> = ({
 
       department: item.department,
       location: item.location,
-      instructions: item.instructions,
       contactPerson: item.contactPerson,
       email: item.email,
       phoneNumber: item.phoneNumber,
@@ -110,6 +108,7 @@ const EditItemForm: FC<Props> = ({
     },
     updateAdvert
   );
+
 
   const [imageURL, setImageURL] = useState(image);
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -359,6 +359,7 @@ export default function Form(props: {
     }
   });
 
+
   const history = useHistory();
 
   const goBackFunc = () => {

--- a/src/components/MyAdverts.tsx
+++ b/src/components/MyAdverts.tsx
@@ -42,6 +42,7 @@ const MyAdverts: FC = () => {
       })
     )) as GraphQLResult<ListAdvertsQuery>;
 
+
     const advertItem: any = result.data?.listAdverts?.items;
     if (advertItem.length > 0) {
       setPaginationOption({

--- a/src/components/RegiveForm.tsx
+++ b/src/components/RegiveForm.tsx
@@ -104,7 +104,6 @@ const RegiveForm: FC<Props> = ({
     },
     updateAdvert
   );
-  console.log(user);
 
   if (redirect && !fileUploading) {
     closeEditformAndFetchItem();

--- a/src/components/RegiveForm.tsx
+++ b/src/components/RegiveForm.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { API, graphqlOperation } from "aws-amplify";
 import Loader from "react-loader-spinner";
 import Form from "./Form";
 import useForm from "../hooks/useForm";
 import { updateAdvert } from "../graphql/mutations";
 import { fieldsEditForm as fields } from "../utils/formUtils";
+import UserContext from "../contexts/UserContext";
 
 interface IareaOfUse {
   indoors: boolean;
@@ -35,15 +36,16 @@ interface Props {
     description?: string;
     department?: string;
     location?: string;
-    instructions?: string;
     contactPerson?: string;
+    giver: string;
+
     email?: string;
     phoneNumber?: number;
     climateImpact: number;
     version: number;
     revisions: number;
-        company?: string;
-
+    company?: string;
+    purchasePrice: number;
   };
   setRegive: React.Dispatch<React.SetStateAction<boolean>>;
   closeEditformAndFetchItem: () => void;
@@ -54,6 +56,8 @@ const RegiveForm: FC<Props> = ({
   item,
   closeEditformAndFetchItem,
 }: Props) => {
+  const { user } = useContext(UserContext);
+
   const {
     values,
     handleInputChange,
@@ -86,20 +90,21 @@ const RegiveForm: FC<Props> = ({
         outside: item.areaOfUse[0].outside,
       },
       description: item.description,
-      company: item.company,
-
-      department: item.department,
-      location: item.location,
-      instructions: item.instructions,
-      contactPerson: item.contactPerson,
-      email: item.email,
-      phoneNumber: item.phoneNumber,
+      company: user.company ? user.company : "",
+      department: user.department ? user.department : "",
+      location: user.address ? user.address : "",
+      contactPerson: user.name ? user.name : "",
+      email: user.email ? user.email : "",
+      phoneNumber: item.phoneNumber ? item.phoneNumber : "",
       climateImpact: item.climateImpact,
       version: 0,
       revisions: item.revisions + 1,
+      purchasePrice: item.purchasePrice ? item.purchasePrice : "",
+      giver: user.sub,
     },
     updateAdvert
   );
+  console.log(user);
 
   if (redirect && !fileUploading) {
     closeEditformAndFetchItem();

--- a/src/pages/ItemDetails.tsx
+++ b/src/pages/ItemDetails.tsx
@@ -547,7 +547,8 @@ const ItemDetails: FC<ParamTypes> = () => {
   const goBackFunc = () => {
     history.goBack();
   };
- 
+
+  console.log(item);
 
   const mailtoHref = `mailto:${item.email}?subject=En kollega vill Haffa "${item.title}"&body=Hej ${item.contactPerson}!%0d%0aDin kollega ${user.name} vill Haffa "${item.title}" och har en fundering:`;
   const telHref = `tel:${item.phoneNumber}`;

--- a/src/pages/ItemDetails.tsx
+++ b/src/pages/ItemDetails.tsx
@@ -548,8 +548,6 @@ const ItemDetails: FC<ParamTypes> = () => {
     history.goBack();
   };
 
-  console.log(item);
-
   const mailtoHref = `mailto:${item.email}?subject=En kollega vill Haffa "${item.title}"&body=Hej ${item.contactPerson}!%0d%0aDin kollega ${user.name} vill Haffa "${item.title}" och har en fundering:`;
   const telHref = `tel:${item.phoneNumber}`;
 


### PR DESCRIPTION
**Explain the changes you’ve made**
added user.sub to giver after regive
changed title in "saker att hämta" depending on the items.length

**Explain why these changes are made**
 Because the giver should be the right person when an avert is regiven. 

**Explain your solution**
 I added a row with "giver: user.sub" in regiveForm file. And autofilled the fields with the users information when regiving. 

**How to test the changes?**
https://testanna.d21bj89y0jdxx1.amplifyapp.com 
regive an advert (that was not your own) and make sure it shows under "mina annonser"
and see how the titles change depending on if your list is empty under "saker att hämta"

